### PR TITLE
feat: add an option to bind other props

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ import { plugin } from 'vue-function-api'
 
 Vue.use(plugin)
 
-// Optionally pass in some options
+// Optionally, pass in some options
 Vue.use(plugin, { props: ['router'] })
 ```
 
@@ -346,15 +346,19 @@ You can bind other properties using `props` option on install：
 
 ```js
 import Vue from 'vue'
+import VueRouter from 'vue-router'
 import { plugin } from 'vue-function-api'
 
 Vue.use(plugin, { props: ['router'] })
 
-const MyComponent = {
+const router = new VueRouter()
+
+new Vue({
+  router,
   setup(props, context) {
     context.router === context.root.$router // true
   }
-}
+})
 ```
 
 # Misc

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ import Vue from 'vue'
 import { plugin } from 'vue-function-api'
 
 Vue.use(plugin)
+
+// Optionally pass in some options
+Vue.use(plugin, { props: ['router'] })
 ```
 
 After installing the plugin you can use the new [function API](#API) to compose your component.
@@ -338,6 +341,21 @@ Full properties list:
 * slots
 * attrs
 * emit
+
+You can bind other properties using `props` option on install：
+
+```js
+import Vue from 'vue'
+import { plugin } from 'vue-function-api'
+
+Vue.use(plugin, { props: ['router'] })
+
+const MyComponent = {
+  setup(props, context) {
+    context.router === context.root.$router // true
+  }
+}
+```
 
 # Misc
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -58,6 +58,9 @@ import Vue from 'vue'
 import { plugin } from 'vue-function-api'
 
 Vue.use(plugin)
+
+// 也可以传入一个可选的选项对象
+Vue.use(plugin, { props: ['router'] })
 ```
 
 安装插件后，您就可以使用新的[函数式 API](#API)来书写组件了。
@@ -325,6 +328,21 @@ const Descendent = {
 * slots
 * attrs
 * emit
+
+可以在安装时通过 `props` 选项绑定其他实例属性：
+
+```js
+import Vue from 'vue'
+import { plugin } from 'vue-function-api'
+
+Vue.use(plugin, { props: ['router'] })
+
+const MyComponent = {
+  setup(props, context) {
+    context.router === context.root.$router // true
+  }
+}
+```
 
 ## Wrapper (包装对象)
 > 以下内容引自 [尤雨溪知乎专栏](https://zhuanlan.zhihu.com/p/68477600)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -329,19 +329,23 @@ const Descendent = {
 * attrs
 * emit
 
-可以在安装时通过 `props` 选项绑定其他实例属性：
+你也可以在安装时通过 `props` 选项绑定其他实例属性：
 
 ```js
 import Vue from 'vue'
+import VueRouter from 'vue-router'
 import { plugin } from 'vue-function-api'
 
 Vue.use(plugin, { props: ['router'] })
 
-const MyComponent = {
+const router = new VueRouter()
+
+new Vue({
+  router,
   setup(props, context) {
     context.router === context.root.$router // true
   }
-}
+})
 ```
 
 ## Wrapper (包装对象)

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -4,6 +4,10 @@ declare global {
   interface Window {
     Vue: VueConstructor;
   }
+
+  interface Options {
+    props?: Array;
+  }
 }
 
 declare module 'vue/types/vue' {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,11 @@ declare module 'vue/types/options' {
   }
 }
 
-const _install = (Vue: VueConstructor) => install(Vue, mixin);
+const defaultOptions = {
+  props: [],
+};
+const _install = (Vue: VueConstructor, options: Options = defaultOptions) =>
+  install(Vue, mixin, options);
 const plugin = {
   install: _install,
 };

--- a/src/install.ts
+++ b/src/install.ts
@@ -34,7 +34,11 @@ function mergeData(to: AnyObject, from?: AnyObject): Object {
   return to;
 }
 
-export function install(Vue: VueConstructor, _install: (Vue: VueConstructor) => void) {
+export function install(
+  Vue: VueConstructor,
+  _install: (Vue: VueConstructor, options: Options) => void,
+  options: Options
+) {
   if (currentVue && currentVue === Vue) {
     if (process.env.NODE_ENV !== 'production') {
       assert(false, 'already installed. Vue.use(plugin) should be called only once');
@@ -52,5 +56,5 @@ export function install(Vue: VueConstructor, _install: (Vue: VueConstructor) => 
   };
 
   setCurrentVue(Vue);
-  _install(Vue);
+  _install(Vue, options);
 }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -72,7 +72,7 @@ function waitPropsResolved(vm: VueInstance, cb: (v: VueInstance, props: Record<a
   });
 }
 
-export function mixin(Vue: VueConstructor) {
+export function mixin(Vue: VueConstructor, options: Options) {
   // We define the setup hook on prototype,
   // which avoids Object.defineProperty calls for each instance created.
   proxy(Vue.prototype, SetupHookEvent, {
@@ -154,7 +154,7 @@ export function mixin(Vue: VueConstructor) {
 
   function createSetupContext(vm: VueInstance & { [x: string]: any }): SetupContext {
     const ctx = {} as SetupContext;
-    const props = ['parent', 'root', 'refs', 'slots', 'attrs'];
+    const props = ['parent', 'root', 'refs', 'slots', 'attrs', ...options.props];
     const methodReturnVoid = ['emit'];
     props.forEach(key => {
       proxy(ctx, key, {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -154,7 +154,7 @@ export function mixin(Vue: VueConstructor, options: Options) {
 
   function createSetupContext(vm: VueInstance & { [x: string]: any }): SetupContext {
     const ctx = {} as SetupContext;
-    const props = ['parent', 'root', 'refs', 'slots', 'attrs', ...options.props];
+    const props = ['parent', 'root', 'refs', 'slots', 'attrs'].concat(options.props);
     const methodReturnVoid = ['emit'];
     props.forEach(key => {
       proxy(ctx, key, {


### PR DESCRIPTION
This PR makes the following possible:

```js
import Vue from 'vue'
import VueRouter from 'vue-router'
import { plugin } from 'vue-function-api'

Vue.use(plugin, { props: ['router'] })

const router = new VueRouter()

new Vue({
  router,
  setup(props, context) {
    context.router === context.root.$router // true
  }
})
```

I'm not familiar with TypeScript, feel free to correct me :P