### PR TITLE
Expose isWrapper in export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import Vue, { VueConstructor } from 'vue';
 import { SetupContext } from './types/vue';
 import { currentVue } from './runtimeContext';
-import { Wrapper } from './wrappers';
+import { Wrapper, isWrapper } from './wrappers';
 import { install } from './install';
 import { mixin } from './setup';
 
@@ -25,7 +25,7 @@ if (currentVue && typeof window !== 'undefined' && window.Vue) {
   _install(window.Vue);
 }
 
-export { plugin, Wrapper };
+export { plugin, Wrapper, isWrapper };
 export { set } from './reactivity';
 export * from './ts-api';
 export * from './functions/state';


### PR DESCRIPTION
For AlbertBrand/vue-async-function#1 I want to check whether a value is wrapped. There is already a function for it but it's not exposed. This PR exposes the `isWrapper` function so I can start using it.