### PR TITLE
fix: fix recursive fire initSetup in safeRunCb

### DIFF
--- a/src/setup.ts
+++ b/src/setup.ts
@@ -12,11 +12,15 @@ let disableSetup = false;
 // `cb` should be called right after props get resolved
 function waitPropsResolved(vm: VueInstance, cb: (v: VueInstance, props: Record<any, any>) => void) {
   const safeRunCb = (props: Record<any, any>) => {
+    let callOnce = false;
     // Running `cb` under the scope of a dep.Target, otherwise the `Observable`
     // in `cb` will be unexpectedly colleced by the current dep.Target.
     const dispose = watch(
       () => {
-        cb(vm, props);
+        if (!callOnce) {
+          callOnce = true;
+          cb(vm, props);
+        }
       },
       noopFn,
       { lazy: false, deep: false, flush: 'sync' }

--- a/test/functions/watch.spec.js
+++ b/test/functions/watch.spec.js
@@ -368,4 +368,27 @@ describe('Hooks watch', () => {
       expect(spy).toHaveBeenCalledWith(2, 1);
     }).then(done);
   });
+
+  it('should not collect wrong deps in watch', done => {
+    const vm = new Vue({
+      setup() {
+        const a = value(1);
+        const b = value(9);
+        watch(a, (newValue, oldValue) => {
+          spy(newValue, oldValue);
+          b.value++;
+        });
+        return {
+          a,
+          b,
+        };
+      },
+      template: `<div>{{a}} {{b}}</div>`,
+    }).$mount();
+    expect(spy.mock.calls.length).toBe(1);
+    vm.b++;
+    waitForUpdate(() => {
+      expect(spy.mock.calls.length).toBe(1);
+    }).then(done);
+  });
 });


### PR DESCRIPTION
I found when assign a `value` in `watch` with `lazy = false`, it will fire the callback (`initSetup`) in `safeRunCb` recursively.

Reproduce code: 

```javascript
new Vue({
  setup() {
    const a = value(1);
    const b = value(9);
    watch(a, () => {
      b.value++;
    });
    return { a, b };
  },
  template: `<div>{{a}} {{b}}</div>`
}).$mount();
```

I think the reason is when touches `b` in watch's callback, the `b` will be collected by the scope of `dep.Target` created in `safeRunCb`, then its value changes and will trigger an update in that scope. And it becomes an infinite loop.
