### PR TITLE
Add test verifying mixins don't break computed properties

### DIFF
--- a/test/functions/computed.spec.js
+++ b/test/functions/computed.spec.js
@@ -166,4 +166,31 @@ describe('Hooks computed', () => {
     });
     expect(() => vm.a).toThrowError('rethrow');
   });
+
+  it('Mixins should not break computed properties', () => {
+    const ExampleComponent = Vue.extend({
+      props: ['test'],
+      render: h => h('div'),
+      setup: props => ({ example: computed(() => props.test) }),
+    });
+
+    Vue.mixin({
+      computed: {
+        foobar() {
+          return 'test';
+        },
+      },
+    });
+
+    const app = new Vue({
+      render: h =>
+        h('div', [
+          h(ExampleComponent, { props: { test: 'A' } }),
+          h(ExampleComponent, { props: { test: 'B' } }),
+        ]),
+    }).$mount();
+
+    expect(app.$children[0].example).toBe('A');
+    expect(app.$children[1].example).toBe('B');
+  });
 });


### PR DESCRIPTION
In the current version of vue-function-api (2.0.6) if you define a mixin with computed properties usages of `computed()` will break when you have more than one component of a given type (like in a v-for list). The computed properties will return the values from the first component even for all other instances.

The master branch does **not** have this problem (awesome! — do you know when a release will be tagged?) but I thought having an explicit test for this would be useful to ensure no regressions occur.