### PR TITLE
README.md - fix some grammatical errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ Full properties list:
 
 # Misc
 
-- Due to the limitation of Vue2.x's public API, vue-function-api inevitably introduces some extra workload. This shouldn't concern you unless you are already pushing your environment to the extreme.
+- Due to the limitation of `Vue2.x`'s public API, `vue-function-api` inevitably introduces some extra workload. This shouldn't concern you unless you are already pushing your environment to the extreme.
 
 
 [wrapper]: https://github.com/vuejs/rfcs/blob/function-apis/active-rfcs/0000-function-api.md#why-do-we-need-value-wrappers

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ Full properties list:
 
 # Misc
 
-- Due to the limitation of Vue2.x's public API. vue-function-api inevitably introduces some extra workload. This shouldn't concern you unless you are already pushing your environment to the extreme.
+- Due to the limitation of Vue2.x's public API, vue-function-api inevitably introduces some extra workload. This shouldn't concern you unless you are already pushing your environment to the extreme.
 
 
 [wrapper]: https://github.com/vuejs/rfcs/blob/function-apis/active-rfcs/0000-function-api.md#why-do-we-need-value-wrappers

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ Full properties list:
 
 # Misc
 
-- Due the the limitation of `Vue2.x`'s public API. `vue-function-api` inevitably introduces some extra workload. This shouldn't concern you unless are already pushing your environment to the extreme.
+- Due to the limitation of Vue2.x's public API. vue-function-api inevitably introduces some extra workload. This shouldn't concern you unless you are already pushing your environment to the extreme.
 
 
 [wrapper]: https://github.com/vuejs/rfcs/blob/function-apis/active-rfcs/0000-function-api.md#why-do-we-need-value-wrappers


### PR DESCRIPTION
HI!

I just read the README.md documentation and found some visible grammatical errors in the Misc. section. So here's a little PR to fix those grammatical errors.

Thanks!