### PR TITLE
Fix storage of DOM elements

### DIFF
--- a/src/reactivity/observable.ts
+++ b/src/reactivity/observable.ts
@@ -1,6 +1,6 @@
 import { AnyObject } from '../types/basic';
 import { getCurrentVue } from '../runtimeContext';
-import { isObject, def, hasOwn } from '../utils';
+import { isObject, def, hasOwn, isDOM } from '../utils';
 import { isWrapper } from '../wrappers';
 import { AccessControIdentifierlKey, ObservableIdentifierKey } from '../symbols';
 
@@ -11,7 +11,7 @@ const ObservableIdentifier = {};
  * We can do unwrapping and other things here.
  */
 function setupAccessControl(target: AnyObject) {
-  if (!isObject(target) || Array.isArray(target) || isWrapper(target)) {
+  if (!isObject(target) || Array.isArray(target) || isWrapper(target) || isDOM(target)) {
     return;
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,6 +45,10 @@ export function isObject(val: unknown): val is Record<any, any> {
   return val !== null && typeof val === 'object';
 }
 
+export function isDOM(val: unknown): val is HTMLElement {
+  return val instanceof HTMLElement;
+}
+
 export function isPlainObject<T extends Object = {}>(x: unknown): x is T {
   return toString(x) === '[object Object]';
 }

--- a/test/functions/state.spec.js
+++ b/test/functions/state.spec.js
@@ -1,4 +1,5 @@
 const Vue = require('vue/dist/vue.common.js');
+const { JSDOM } = require('jsdom');
 const { plugin, state, value, watch, set } = require('../../src');
 
 Vue.use(plugin);
@@ -185,5 +186,19 @@ describe('value/unwrapping', () => {
     expect(dummy).toBe(2);
     obj.a.foo++;
     expect(dummy).toBe(3);
+  });
+
+  it('should not break when storing DOM elements', () => {
+    const el = value(null);
+    const window = new JSDOM(``).window;
+    const document = window.document;
+    const select = document.createElement('select');
+
+    // This test passes… but it's not properly testing the condition because
+    // 1. JSDOM's HTMLSelectElement doesn't actually behave identically
+    // 2. expect(select).toBeInstanceOf(HTMLSelectElement) // fails
+    // 3. expect(select).toBeInstanceOf(window.HTMLSelectElement) // passes
+
+    expect(() => (el.value = select)).not.toThrow();
   });
 });


### PR DESCRIPTION
If you store a DOM element in a `value()` you may get errors from the browser or in more rare cases (explained in the commit message) an error during vnode patching.

The vnode patching error feels like something inside Vue is wrong for something like this to be able to cause that kind of error but I want to look more into it to see why that might be happening.

In any case this appears to fix the issue from what I can tell. I have not written a test for it yet, just a stub. I need to figure out how to write one that will verify the problem whether or not its run in a browser.