### PR TITLE
fix: provide() should work when combined with 2.x provide syntax

### DIFF
--- a/src/apis/inject.ts
+++ b/src/apis/inject.ts
@@ -34,7 +34,11 @@ function createInjectValue<T>(value: T, vm: ComponentInstance): Ref<T> {
 export function provide<T>(key: InjectionKey<T> | string, value: T | Ref<T>): void {
   const vm: any = ensureCurrentVMInFn('provide');
   if (!vm._provided) {
-    vm._provided = {};
+    const provideCache = {};
+    Object.defineProperty(vm, '_provided', {
+      get: () => provideCache,
+      set: v => Object.assign(provideCache, v),
+    });
   }
 
   vm._provided[key as string] = value;

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -123,12 +123,6 @@ export function mixin(Vue: VueConstructor) {
       return;
     }
 
-    const provideCache = {};
-    Object.defineProperty(vm, '_provided', {
-      get: () => provideCache,
-      set: v => Object.assign(provideCache, v),
-    });
-
     const { data } = $options;
     // wapper the data option, so we can invoke setup before data get resolved
     $options.data = function wrappedData() {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -97,6 +97,7 @@ export function mixin(Vue: VueConstructor) {
   /**
    * Vuex init hook, injected into each instances init hooks list.
    */
+
   function functionApiInit(this: ComponentInstance) {
     const vm = this;
     const $options = vm.$options;
@@ -121,6 +122,12 @@ export function mixin(Vue: VueConstructor) {
       }
       return;
     }
+
+    const provideCache = {};
+    Object.defineProperty(vm, '_provided', {
+      get: () => provideCache,
+      set: v => Object.assign(provideCache, v),
+    });
 
     const { data } = $options;
     // wapper the data option, so we can invoke setup before data get resolved

--- a/test/apis/inject.spec.js
+++ b/test/apis/inject.spec.js
@@ -121,4 +121,30 @@ describe('Hooks provide/inject', () => {
     obj.value = {};
     expect(warn.mock.calls[0][0]).toMatch("[Vue warn]: The injectd value can't be re-assigned");
   });
+
+  it('should work when combined with 2.x provide option', () => {
+    const State = Symbol();
+    let obj1;
+    let obj2;
+    new Vue({
+      template: `<child/>`,
+      setup() {
+        provide(State, { msg: 'foo' });
+      },
+      provide: {
+        X: { msg: 'bar' },
+      },
+      components: {
+        child: {
+          setup() {
+            obj1 = inject(State);
+            obj2 = inject('X');
+          },
+          template: `<div/>`,
+        },
+      },
+    }).$mount();
+    expect(obj1.value.msg).toBe('foo');
+    expect(obj2.value.msg).toBe('bar');
+  });
 });


### PR DESCRIPTION
Since for `provided()` we manually assign to `vm._provided` during `beforeCreate` Vue will overwrite whatever we have set if there's a 2.x API `$options.provide`, which gets assigned to `_provided` *after* `beforeCreate`.

I solved it with a setter.

### Why is this important?

Because plugins or mixins may add their own provide options, which would then override provides from `setup` 

close #66