### PR TITLE
fix: README.md #typescript missing import

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ To let TypeScript properly infer types inside Vue component options, you need to
 
 ```ts
 import Vue from 'vue';
+import { createComponent } from 'vue-function-api';
 
 const Component = createComponent({
   // type inference enabled

--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ After installing the plugin you can use the [Composition API](https://vue-compos
 To let TypeScript properly infer types inside Vue component options, you need to define components with `createComponent`:
 
 ```ts
-import Vue from 'vue';
 import { createComponent } from 'vue-function-api';
 
 const Component = createComponent({

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -57,7 +57,6 @@ Vue.use(VueFunctionApi);
 为了让 TypeScript 正确的推到类型，我们必须使用 `createComponent` 来定义组件:
 
 ```ts
-import Vue from 'vue';
 import { createComponent } from 'vue-function-api';
 
 const Component = createComponent({

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -58,6 +58,7 @@ Vue.use(VueFunctionApi);
 
 ```ts
 import Vue from 'vue';
+import { createComponent } from 'vue-function-api';
 
 const Component = createComponent({
   // 启用类型推断


### PR DESCRIPTION
a missing import found in
 [https://github.com/vuejs/vue-function-api#typescript](https://github.com/vuejs/vue-function-api#typescript)